### PR TITLE
WIP: Platformio build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ dkms.conf
 *.phil
 *.map
 
+# PlatformIO directory
+.pio/

--- a/Hoverboard/HUGS/Inc/gd32f1x0_libopt.h
+++ b/Hoverboard/HUGS/Inc/gd32f1x0_libopt.h
@@ -1,0 +1,32 @@
+/*!
+    \file  gd32f1x0_libopt.h
+    \brief library optional for gd32f1x0
+*/
+
+/*
+    Copyright (C) 2017 GigaDevice
+
+    2014-12-26, V1.0.0, platform GD32F1x0(x=3,5)
+    2016-01-15, V2.0.0, platform GD32F1x0(x=3,5,7,9)
+    2016-04-30, V3.0.0, firmware update for GD32F1x0(x=3,5,7,9)
+    2017-06-19, V3.1.0, firmware update for GD32F1x0(x=3,5,7,9)
+*/
+
+#ifndef GD32F1X0_LIBOPT_H
+#define GD32F1X0_LIBOPT_H
+
+#include "gd32f1x0_adc.h"
+#include "gd32f1x0_dbg.h"
+#include "gd32f1x0_dma.h"
+#include "gd32f1x0_gpio.h"
+#include "gd32f1x0_syscfg.h"
+#include "gd32f1x0_i2c.h"
+#include "gd32f1x0_fwdgt.h"
+#include "gd32f1x0_pmu.h"
+#include "gd32f1x0_rcu.h"
+#include "gd32f1x0_timer.h"
+#include "gd32f1x0_usart.h"
+#include "gd32f1x0_wwdgt.h"
+#include "gd32f1x0_misc.h"
+
+#endif /* GD32F1X0_LIBOPT_H */

--- a/Hoverboard/HUGS/Src/bldc.c
+++ b/Hoverboard/HUGS/Src/bldc.c
@@ -50,7 +50,9 @@ const int32_t WHEEL_PERIMETER    = 530 ;  // mm
 const int32_t SPEED_TICKS_FACTOR = 188444 ;  // Divide factor by speed to get ticks per cycle, or visa versa.
 const int32_t SINE_TICKS_FACTOR  = 3010   ;  // Divide factor by speed to get ticks per degree.
 const int32_t MIN_SPEED          = 5 ;       // min usable speed in mm/S
-const int32_t MAX_PHASE_PERIOD   = SPEED_TICKS_FACTOR / MIN_SPEED ;   // one phase count @ MIN_SPEED
+// Work around "initializer element is not constant" error from gcc. Original code was:
+//            MAX_PHASE_PERIOD   = SPEED_TICKS_FACTOR / MIN_SPEED ;
+const int32_t MAX_PHASE_PERIOD   = 188444 / 5 ;   // one phase count @ MIN_SPEED
 const float MM_PER_CYCLE_FLOAT   = 5.888;	   //  (530 / 90)
 
 //----------------------------------------------------------------------------

--- a/Hoverboard/HUGS/Src/bldc.c
+++ b/Hoverboard/HUGS/Src/bldc.c
@@ -141,7 +141,7 @@ int16_t bldcFilteredPwm = 0;
 //----------------------------------------------------------------------------
 // Block PWM calculation based on position
 //----------------------------------------------------------------------------
-__INLINE void blockPWM(int pwm, int pwmPos, int *y, int *b, int *g)
+static __INLINE void blockPWM(int pwm, int pwmPos, int *y, int *b, int *g)
 {
 	// Note:  These now cycle from 0 to 5 with positive applied PWM
   switch(pwmPos)

--- a/Hoverboard/HUGS/add_nanolib.py
+++ b/Hoverboard/HUGS/add_nanolib.py
@@ -1,0 +1,3 @@
+Import("env")
+#env.Append(LINKFLAGS=["--specs=nano.specs"])
+env.Append(LINKFLAGS=["--specs=nosys.specs", "--specs=nano.specs"])

--- a/Hoverboard/HUGS/boards/gd32f130c6.json
+++ b/Hoverboard/HUGS/boards/gd32f130c6.json
@@ -1,0 +1,40 @@
+{
+  "build": {
+    "core": "gd32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DGD32F1x0 -DGD32F130_150 -D__GD32F130_SUBFAMILY -D__GD32F1x0_FAMILY",
+    "f_cpu": "72000000L",
+    "mcu": "gd32f130c6t6"
+  },
+  "connectivity": [
+  ],
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "GD32F130C6",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F10x.svd"
+  },
+  "frameworks": [
+    "stm32cube",
+    "spl"
+  ],
+  "name": "Generic GD32F130C6T6",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 32768,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "mbed"
+    ]
+  },
+  "url": "https://www.gigadevice.com/microcontroller/gd32f130c6t6/",
+  "vendor": "GigaDevice"
+}

--- a/Hoverboard/HUGS/boards/gd32f130c8.json
+++ b/Hoverboard/HUGS/boards/gd32f130c8.json
@@ -1,0 +1,40 @@
+{
+  "build": {
+    "core": "gd32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DGD32F1x0 -DGD32F130_150 -D__GD32F130_SUBFAMILY -D__GD32F1x0_FAMILY",
+    "f_cpu": "72000000L",
+    "mcu": "gd32f130c8t6"
+  },
+  "connectivity": [
+  ],
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "GD32F130C8",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F10x.svd"
+  },
+  "frameworks": [
+    "stm32cube",
+    "spl"
+  ],
+  "name": "Generic GD32F130C8T6",
+  "upload": {
+    "maximum_ram_size": 8196 ,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "mbed"
+    ]
+  },
+  "url": "https://www.gigadevice.com/microcontroller/gd32f130c8t6/",
+  "vendor": "GigaDevice"
+}

--- a/Hoverboard/HUGS/platformio.ini
+++ b/Hoverboard/HUGS/platformio.ini
@@ -1,0 +1,31 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = Src
+include_dir = Inc
+
+[env]
+; globally override framework-spl for all environments.
+; new version on the way that fixes a compile error for arm_math.h
+; for now you have to manually copy the 3 files arm_common_tables.h, arm_const_structs.h and arm_math.h
+; from C:\Users\<user>\.platformio\packages\framework-spl\stm32\cmsis\cores\stm32
+; to   C:\Users\<user>\.platformio\packages\framework-spl\gd32\cmsis\cores\gd32
+platform_packages = 
+    maxgerhardt/framework-spl@2.10300.0
+
+[env:GD32F130C8T6]
+platform = ststm32
+board = gd32f130c8
+debug_tool = stlink
+framework = spl
+build_flags = -IInc
+extra_scripts = add_nanolib.py
+;lib_deps = file://RTE/Device/GD32F130C8


### PR DESCRIPTION
Firstly, thank you for documenting your working with the hoverboard hacking. It makes me feel more confident about making community contributions to this repository.

I don't currently have access to a machine for running kiel on, so I have been using platformio from my raspberry pi 4 (using vscode remote). Would you be interested in having the platformIO build support upstream?

maxgerhardt has been super helpful with this effort on the platformio forums https://community.platformio.org/t/library-for-gd32f130c8/7410 so I can't take credit for very much of this code.

There is a bit more work to be done before this PR can be merged. Specifically:
- [ ] update the readme with build, flash and unlock instructions (also need to disable a watchdog timer, which kiel does automatically, but caused us a world of pain when we started out)
- [ ] wait for maxgerhardt to release a new version of maxgerhardt/framework-spl and update it in platformio.ini

This PR is part of a larger project, which is tracked on trello at https://trello.com/c/UuC7P5Xo/37-make-firmware-turn-the-motors . In my next PR, I would like to make a shared library for the protocol definition + CRC code, and use that to write a raspberry pi program for sending movement commands. Does this sound like a sensible plan?